### PR TITLE
Add post_start command for docker compose

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,10 @@
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan migrate --graceful --ansi"
         ],
+        "post-container-restart": [
+            "@php artisan migrate --force",
+            "@php artisan scribe:generate"
+        ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74,#34d399\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" \"npx chokidar 'app/Http/Controllers/api/**/*.php' -c 'php artisan scribe:generate'\" --names=server,queue,logs,vite,scribe"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,9 @@ services:
     ports:
       - "8080:8080"
       - "8443:8443"
+    # for subsequent container restarts
+    post_start:
+      - command: composer post-container-restart
     environment:
       - PHP_OPCACHE_ENABLE=1
       - APP_KEY=${APP_KEY:?APP_KEY must be set}

--- a/docs/deployments/docker-compose.md
+++ b/docs/deployments/docker-compose.md
@@ -11,6 +11,9 @@ services:
     ports:
       - "8080:8080" # HTTP
       - "8443:8443" # HTTPS
+    # Not useful when first time starts the container. Uncomment after completed the 'First setup' section.
+    # post_start:
+    #   - command: composer post-container-restart
     environment:
       - PHP_OPCACHE_ENABLE=1
       - APP_KEY=${APP_KEY:?APP_KEY must be set}


### PR DESCRIPTION
This PR add a custom composer script that can be called to automate tasks after docker compose updates images and container restarts. 