### PR TITLE
Install gd extension in Dockerfile

### DIFF
--- a/.docker/production/Dockerfile
+++ b/.docker/production/Dockerfile
@@ -26,7 +26,7 @@ FROM serversideup/php:8.4-fpm-nginx-alpine AS final
 USER root
 
 # Install php extensions: https://serversideup.net/open-source/docker-php/docs/customizing-the-image/installing-additional-php-extensions
-RUN install-php-extensions intl
+RUN install-php-extensions intl gd
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
This PR update Dockerfile to install gd php extension. Closes #52 

<img width="1920" height="1080" alt="Screenshot 2026-06-17 at 12 02 53 AM" src="https://github.com/user-attachments/assets/90c56759-f560-469b-be33-0871fd3224ae" />